### PR TITLE
Download page: simplify translation of Ubuntu warning

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -80,6 +80,11 @@
 
 </div>
 
+  {% if page.version > 2 %}
+  {{page.ubuntu_warning}} <a href="https://bugs.launchpad.net/snapstore/+bug/1803914">1</a>,
+  <a href="https://bugs.launchpad.net/launchpad/+bug/1331914">2</a>
+  {% endif %}
+
   <h2 style="text-align: center">{{ page.patient }}</h2>
   <p>{{ page.notesync | replace: '$(DATADIR_SIZE)', site.data.stats.datadir_gb | replace: '$(PRUNED_SIZE)', site.data.stats.pruned_gb | replace: '$(MONTHLY_RANGE_GB)', site.data.stats.monthly_storage_increase_range_gb }} {{ page.full_node_guide }}</p>
 

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -5,7 +5,7 @@ type: pages
 layout: page
 lang: en
 share: false
-version: 2
+version: 3
 
 ## These strings need to be localized.  In the listing below, the
 ## comment above each entry contains the English text.  The key before the
@@ -59,9 +59,12 @@ verify_download: "Verify your download"
 verification_recommended: >
   Download verification is optional but highly recommended.
   Click one of the lines below to view verification instructions for that platform.
-  Note that due to a <a href=\"https://bugs.launchpad.net/snapstore/+bug/1803914\">series</a>
-  <a href=\"https://bugs.launchpad.net/launchpad/+bug/1331914\">of</a> mishandlings of security issues
-  by Canonical/Ubuntu, use of Bitcoin wallets on Ubuntu is strongly discouraged.
+
+ubuntu_warning: >
+  <b>Warning:</b>  We strongly discourage using Bitcoin wallets on
+  Ubuntu.  This is the result of Canonical Ltd and the Ubuntu
+  development team mishandling multiple security issues:
+
 windows_instructions: "Windows verification instructions"
 macos_instructions: "MacOS verification instructions"
 linux_instructions: "Linux verification instructions (not for Ubuntu PPA)"


### PR DESCRIPTION
- Fixes a rendering bug (the `href=\"http...\"` shouldn't have the escapes since you converted its YAML type)
- Uses page versioning so that translators know to update the page
- Moves the warning text to a new variable so that none of the existing next needs to be retranslated
- Moves the warning higher on the page to just below the download links, which I think is a more logical position (see screenshot below)
- Moves the links to issues outside of the translated text, making it easy to add more without affecting translations if more issues appear.  I think the rephrasing to make this work also improves the text by putting the most important information (don't use Ubuntu) first.

Preview of the warning:

![2019-01-09-16_38_43_361334332](https://user-images.githubusercontent.com/61096/50930122-1763a180-142d-11e9-8944-1b5ca4d20c50.png)

